### PR TITLE
Handling and Reporting Failures

### DIFF
--- a/backend/pkg/monitor/pipeline_monitor.go
+++ b/backend/pkg/monitor/pipeline_monitor.go
@@ -156,8 +156,8 @@ func (c *Config) MonitorAndLog() {
 							stepStatus = db.Error
 						}
 						stage.Steps[stepIdx].Status = stepStatus
-						//update the overall stage status only if the current step is last step
-						c.updateStatuses(stage, stepIdx == len(stage.Steps)-1)
+						//update the overall stage status only if the current step is last step or any error occurred
+						c.updateStatuses(stage, (stepIdx == len(stage.Steps)-1 || stepStatus == db.Error))
 					default:
 						//no requirement to handle other cases
 					}
@@ -213,7 +213,7 @@ func (c *Config) updateStatuses(stage *db.Stage, updateStage bool) {
 	dbConn := c.DB
 	log := c.Log
 	if err := dbConn.RunInTx(c.Ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		log.Debugf("Updating Status for stage %s of pipeline %s", stage.Name, stage.PipelineFile)
+		log.Infof("Updating Status for stage %s of pipeline %s", stage.Name, stage.PipelineFile)
 
 		if err := updateStepStatus(c.Ctx, dbConn, stage.Steps); err != nil {
 			return err

--- a/examples/hello-world/.drone.yml
+++ b/examples/hello-world/.drone.yml
@@ -9,6 +9,7 @@ steps:
   image: kameshsampath/drone-java-maven-plugin:v1.0.3
   pull: if-not-exists
   settings:
+    #maven_mirror_url: http://nexus:8081/repository/maven-public/
     goals:
     - clean 
     - test
@@ -16,6 +17,7 @@ steps:
   image: kameshsampath/drone-java-maven-plugin:v1.0.3
   pull: if-not-exists
   settings:
+    #maven_mirror_url: http://nexus:8081/repository/maven-public/
     goals:
     - clean 
     - install

--- a/ui/src/components/PipelineStatus.tsx
+++ b/ui/src/components/PipelineStatus.tsx
@@ -11,7 +11,7 @@ export const PipelineStatus = (props) => {
   const [statusText, setStatusText] = useState('');
 
   useEffect(() => {
-    //console.debug('pipelineFile %s Status %s', pipelineFile, pipelineStatus);
+    console.log('pipelineFile %s Status %s', pipelineFile, pipelineStatus);
 
     switch (pipelineStatus) {
       case 1:

--- a/ui/src/components/dialogs/RunPipelineDialog.tsx
+++ b/ui/src/components/dialogs/RunPipelineDialog.tsx
@@ -255,10 +255,6 @@ export default function RunPipelineDialog({ ...props }) {
             }
             once++;
           },
-          onError(error) {
-            showError(error);
-            return;
-          },
           splitOutputLines: true
         }
       });

--- a/ui/src/components/dialogs/RunPipelineDialog.tsx
+++ b/ui/src/components/dialogs/RunPipelineDialog.tsx
@@ -154,6 +154,10 @@ export default function RunPipelineDialog({ ...props }) {
     ddClient.host.openExternal(href);
   };
 
+  const showError = (err: any) => {
+    ddClient.desktopUI.toast.error(`Error running pipeline :${JSON.stringify(err)}`);
+  };
+
   const runPipeline = async () => {
     console.debug('Running pipeline ', pipelineFile);
     logHandler(undefined, true);
@@ -220,7 +224,12 @@ export default function RunPipelineDialog({ ...props }) {
       let once = 0;
       ddClient.extension.host.cli.exec('run-drone', pipelineExecArgs, {
         stream: {
-          onOutput() {
+          onOutput(data) {
+            console.debug('onOutput:%s', JSON.stringify(data));
+            if (data.stderr) {
+              showError(data.stderr);
+              return;
+            }
             if (once === 1) {
               const stage = stages.find((s) => s.name === stageName);
               //make it writable and set the status
@@ -247,13 +256,14 @@ export default function RunPipelineDialog({ ...props }) {
             once++;
           },
           onError(error) {
-            ddClient.desktopUI.toast.error(`Error running pipeline :${JSON.stringify(error)}`)
+            showError(error);
+            return;
           },
           splitOutputLines: true
         }
       });
     } catch (err) {
-      ddClient.desktopUI.toast.error(`Error running pipeline :${JSON.stringify(err)}`)
+      showError(err);
     } finally {
       props.onClose();
     }

--- a/ui/src/components/views/StageRunnerView.tsx
+++ b/ui/src/components/views/StageRunnerView.tsx
@@ -135,9 +135,11 @@ export const StageRunnerView = (props) => {
         showLogs(stage, steps[0]);
         return true;
       }
-      const rStep = steps.find((s) => s.status === Status.RUNNING);
-      setSelectedStep(rStep.name);
-      showLogs(stage, rStep);
+      const rStep = steps.find((s) => s.status === Status.RUNNING || s.status === Status.ERROR);
+      if (rStep) {
+        setSelectedStep(rStep.name);
+        showLogs(stage, rStep);
+      }
       return true;
     }
     return true;


### PR DESCRIPTION
Better handling and reporting of pipeline run failures 

- use toast to show the drone run command `stderr` when failed
- make update failure for last step or error